### PR TITLE
chore: Adapt repo to image

### DIFF
--- a/meta-nxp-openthread/conf/layer.conf
+++ b/meta-nxp-openthread/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-openthread = "mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_nxp-openthread = "kirkstone mickledore nanbield scarthgap"
 
 BBFILE_COLLECTIONS += "nxp-openthread"
 BBFILE_PATTERN_nxp-openthread = "^${LAYERDIR}/"

--- a/meta-nxp-otbr/conf/layer.conf
+++ b/meta-nxp-otbr/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-otbr = "mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_nxp-otbr = "kirkstone mickledore nanbield scarthgap"
 
 BBFILE_COLLECTIONS += "nxp-otbr"
 BBFILE_PATTERN_nxp-otbr = "^${LAYERDIR}/"

--- a/meta-nxp-otbr/conf/layer.conf
+++ b/meta-nxp-otbr/conf/layer.conf
@@ -12,7 +12,4 @@ BBFILE_PRIORITY_nxp-otbr = "7"
 
 TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf-compiler"
 PACKAGECONFIG:append:pn-iptables = " libnftnl"
-IMAGE_INSTALL:append = " boost boost-dev boost-staticdev "
-
-IMAGE_INSTALL:append = " packagegroup-nxp-otbr "
 DELTA_KERNEL_DEFCONFIG="${WORKDIR}/kernel-config/*"


### PR DESCRIPTION
Add kirkstone support
Remove boost from dependecy as it weight around 1GB